### PR TITLE
Support addition of <script> tags to virtual DOM

### DIFF
--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -58,12 +58,17 @@ var parseStyles = function(input) {
 module.exports = function createConverter (VNode, VText) {
     var converter = {
         convert: function (node, getVNodeKey, getVHooks) {
-            if (node.type === 'tag') {
+
+            // Patched for Kinja to treat <script> tags as regular tag nodes
+            if (node.type === 'tag' || node.type === 'script') {
                 return converter.convertTag(node, getVNodeKey, getVHooks);
             }
             else if (node.type === 'text') {
                 return new VText(decode(node.data));
+            } else {
+                console.error('Unhandled node type!');
             }
+
         },
         convertTag: function (tag, getVNodeKey, getVHooks) {
             var dataset = getDataset(tag);


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This adds support for converting `<script>` to a VNode in html-to-vdom.  This will resolve issues returning to visual view after inserting scripts in HTML view.
### Related Trello card, wiki page or blog posts

https://trello.com/c/2cZuzTyG/36-scribe-can-t-switch-back-to-visual-view-from-html-view-after-pasting-a-script-including-twitter-embed-codes
