### PR TITLE
Escape value property

### DIFF
--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -8,7 +8,7 @@ var attributesToDecode = {
     'src': true,
     'href': true,
     'alt': true,
-    // Escaping value property is required to <object> based embed, which is using & in the flashparams.
+    // Unescaping value property is required to <object> based embed, which is using & in the flashparams.
     'value': true
 };
 

--- a/lib/htmlparser-to-vdom.js
+++ b/lib/htmlparser-to-vdom.js
@@ -7,7 +7,9 @@ var attributesToDecode = {
     'title': true,
     'src': true,
     'href': true,
-    'alt': true
+    'alt': true,
+    // Escaping value property is required to <object> based embed, which is using & in the flashparams.
+    'value': true
 };
 
 var attributesToRename = {


### PR DESCRIPTION
### What does this PR do? How does it affect users?

Decodes the value attribute on the tags.

Without decoding `&amp;` is duplicated on param tags.

``` html
<param name="flashvars" value="channel=quill18&amp;amp;auto_play=false&amp;amp;start_volume=25&amp;amp;videoId=v3880472&amp;amp;device_id=d196049dedd16e15">
```

With decoding: 

``` html
<param name="flashvars" value="channel=quill18&amp;auto_play=false&amp;start_volume=25&amp;videoId=v3880472&amp;device_id=d196049dedd16e15">
```

In both cases the input was the following:

``` html
<param name="flashvars" value="channel=quill18&auto_play=false&start_volume=25&videoId=v3880472&device_id=d196049dedd16e15"/>
```
### Related Trello card, wiki page or blog posts

https://trello.com/c/ukobjvq3/733-twitch-vod-embeds-show-live-channel-not-vod-content
